### PR TITLE
wetterdienst v0.40.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "wetterdienst" %}
-{% set version = "0.39.0" %}
+{% set version = "0.40.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 98650026c373624859a7b21cee0898f855b50718cd10fa7b91bbadc0546a793a
+  sha256: 9903e5ccbd7fe0ebb67a152e9c47b8d03c74928f9bae47524dc5861c3099593c
 
 build:
   noarch: python


### PR DESCRIPTION
### Important notes
Manual replacement patch for original https://github.com/conda-forge/wetterdienst-feedstock/pull/46, which apparently has **not** been resubmitted by @regro-cf-autotick-bot. Probably because, at this time, the newer version 0.41.0 already is available on PyPI, and the bot skips any older versions?

/cc @kmuehlbauer 

### Ceremony
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
