### PR TITLE
Update list of runtime dependencies in `recipe/meta.yml`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,20 +27,14 @@ requirements:
     - pandas
     - numpy
     - scipy
-    - cachetools
-    - dataclass-wizard
     - dateparser
-    - beautifulsoup4
     - requests
-    - requests-ftp
     - python-dateutil
     - appdirs
     - lxml
     - tqdm
     - PyPDF2
     - tabulate
-    - deprecation
-    - importlib_metadata
     - measurement
     - rapidfuzz
     - Pint
@@ -54,6 +48,15 @@ requirements:
     - environs
     - timezonefinder
     - scikit-learn
+    - plotly
+    - dash-bootstrap-components
+    - fastapi
+    - utm
+    - shapely
+    - pytz
+    - dash
+    - autovizwidget
+    - finesse
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,15 +48,9 @@ requirements:
     - environs
     - timezonefinder
     - scikit-learn
-    - plotly
-    - dash-bootstrap-components
-    - fastapi
     - utm
     - shapely
     - pytz
-    - dash
-    - autovizwidget
-    - finesse
 
 test:
   imports:


### PR DESCRIPTION
This patch just follows the suggestions by `regro-cf-autotick-bot` about packages found by source code inspection but not in the meta.yaml vs. packages found in the meta.yaml but not found by source code inspection.

It addresses our discussion at:
- #57
