### PR TITLE
Use `poetry-core` instead of `poetry`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   host:
     - python >=3.7
     - pip
-    - poetry
+    - poetry-core
   run:
     - python >=3.7
     - pandas


### PR DESCRIPTION
This may unblock release 0.49.0 (#70), because it may provide Poetry 1.2 already, which is needed for serving dependency groups, which got recently introduced into `pyproject.toml` of Wetterdienst, using https://github.com/earthobservations/wetterdienst/commit/0920548871d.

This patch implements the suggestion by @xylar at https://github.com/conda-forge/wetterdienst-feedstock/pull/70#issuecomment-1329708542. Thank you!
