### PR TITLE
Chore: Use `platformdirs` instead of `appdirs`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - requests
     - requests-ftp
     - python-dateutil
-    - appdirs
+    - platformdirs
     - lxml
     - tqdm
     - PyPDF2


### PR DESCRIPTION
This patch accompanies https://github.com/earthobservations/wetterdienst/pull/808.