### PR TITLE
Unpin `backports-datetime-fromisoformat` again

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - wetterdienst = wetterdienst.ui.cli:cli
@@ -26,7 +26,7 @@ requirements:
     - python >=3.9.0,<4.0.0,!=3.9.7,<3.12
     - aenum >=3,<3.2
     - aiohttp >=3.8,<3.9
-    - backports-datetime-fromisoformat >=2,<3 pyh71feb2d_0
+    - backports-datetime-fromisoformat >=2,<3
     - beautifulsoup4 >=4.9,<5
     - cachetools >=5.2,<6
     - click >=8,<9


### PR DESCRIPTION
## About

This patch intends to verify our observations shared at https://github.com/conda-forge/wetterdienst-feedstock/pull/102#issuecomment-1751357548, checking again that the recently released package `backports-datetime-fromisoformat: 2.0.0-pyh0c530f3_1` is indeed broken in one way or another.

## References

- https://github.com/conda-forge/wetterdienst-feedstock/pull/102#issuecomment-1751357548
- https://github.com/conda-forge/wetterdienst-feedstock/pull/104
